### PR TITLE
Add old URL with /blog/ as an alias

### DIFF
--- a/content/post/setup-vs-requirement.md
+++ b/content/post/setup-vs-requirement.md
@@ -1,6 +1,8 @@
 ---
 title: setup.py vs requirements.txt
 date: 2013-07-22
+redirect_from:
+ - wiki/setup-vs-requirement/
 ---
 
 There's a lot of misunderstanding between ``setup.py`` and ``requirements.txt``


### PR DESCRIPTION
This will hopefully restore the old and widely used URL of https://caremad.io/blog/setup-vs-requirement/ which at some point seems to have been replaced by https://caremad.io/2013/07/setup-vs-requirement/

You may also need to add this to your `_config.yml` file:

```
gems:
  - jekyll-redirect-from
whitelist:
  - jekyll-redirect-from
```
